### PR TITLE
Add Go

### DIFF
--- a/lib/languages/go.txt
+++ b/lib/languages/go.txt
@@ -1,0 +1,5 @@
+//
+import
+package
+/*
+*/

--- a/test/languages/go_test.rb
+++ b/test/languages/go_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+module SnippetExtractor
+  module Languages
+    class GoTest < Minitest::Test
+      def test_full_example
+        code = <<~CODE
+          // Package gigasecond constains functionality to add a gigasecond
+          // to a period of time
+          package gigasecond
+
+          import "time"
+
+          // AddGigasecond adds a Gigasecond to the given time
+          func AddGigasecond(t time.Time) time.Time {
+            return t.Add(time.Second * 1e9)
+          }
+        CODE
+
+        expected = <<~CODE
+          func AddGigasecond(t time.Time) time.Time {
+            return t.Add(time.Second * 1e9)
+          }
+        CODE
+
+        assert_equal expected, ExtractSnippet.(code, :go)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds basic support for Go.

There are a couple of edge cases that I'm not sure how to deal with. For instance, we can have:

```go
import (
    "fmt"
    "errors"
)
```

Ideally we remove this entire block, but adding `"` or `)` to the blacklist could also potentially remove interesting lines of code.