### PR TITLE
[Nim] add nim extractor

### DIFF
--- a/lib/languages/nim.txt
+++ b/lib/languages/nim.txt
@@ -1,5 +1,6 @@
 import
 from 
 export
+include
 #
 ]#

--- a/lib/languages/nim.txt
+++ b/lib/languages/nim.txt
@@ -1,0 +1,5 @@
+import
+from 
+export
+#
+]#

--- a/lib/languages/nim.txt
+++ b/lib/languages/nim.txt
@@ -3,4 +3,3 @@ from
 export
 include
 #
-]#

--- a/test/languages/nim_test.rb
+++ b/test/languages/nim_test.rb
@@ -22,6 +22,9 @@ module SnippetExtractor
 
         expected = <<~CODE
           proc twoFer =
+            ##[ doc comment ]##
+            ## more doc comment
+            # A non-doc comment
             discard
         CODE
 

--- a/test/languages/nim_test.rb
+++ b/test/languages/nim_test.rb
@@ -7,8 +7,9 @@ module SnippetExtractor
         code = <<~CODE
           # This is a file
           # With some comments in it
+
           # And a blank line ⬆️
-          # It has some requires like this:
+          # It has some module-related code like this:
           import json
           export json
           from json import nil

--- a/test/languages/nim_test.rb
+++ b/test/languages/nim_test.rb
@@ -18,14 +18,15 @@ module SnippetExtractor
             ##[ doc comment ]##
             ## more doc comment
             discard
+          # A non doc comment
         CODE
 
         expected = <<~CODE
           proc twoFer =
             ##[ doc comment ]##
             ## more doc comment
-            # A non-doc comment
             discard
+          # A non doc comment
         CODE
 
         assert_equal expected, ExtractSnippet.(code, :nim)

--- a/test/languages/nim_test.rb
+++ b/test/languages/nim_test.rb
@@ -5,6 +5,7 @@ module SnippetExtractor
     class NimTest < Minitest::Test
       def test_full_example
         code = <<~CODE
+          ## Module doc comment
           # This is a file
           # With some comments in it
 

--- a/test/languages/nim_test.rb
+++ b/test/languages/nim_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+module SnippetExtractor
+  module Languages
+    class NimTest < Minitest::Test
+      def test_full_example
+        code = <<~CODE
+          # This is a file
+          # With some comments in it
+          # And a blank line ⬆️
+          # It has some requires like this:
+          import json
+          export json
+          from json import nil
+          # And then eventually the code
+          proc twoFer =
+            ##[ doc comment ]##
+            ## more doc comment
+            discard
+        CODE
+
+        expected = <<~CODE
+          proc twoFer =
+            discard
+        CODE
+
+        assert_equal expected, ExtractSnippet.(code, :nim)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm not sure what to do about multiline comments.
In nim they are done like 
```nim
proc twoFer: string =
  #[
    This is my
    multiline comment
  ]#
  "Hello"
```
but there is no indicator at the beginning of the line to tell that it's a comment.